### PR TITLE
Use the exact same package version in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@types/express-session": "^1.17.4",
         "@types/gapi": "0.0.41",
         "@types/gapi.auth2": "0.0.56",
-        "@types/node": "17.0.10",
+        "@types/node": "17.0.21",
         "@types/nouislider": "^9.0.10",
         "@types/passport": "^1.0.7",
         "@types/puppeteer": "^5.4.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/express-session": "^1.17.4",
     "@types/gapi": "0.0.41",
     "@types/gapi.auth2": "0.0.56",
-    "@types/node": "17.0.10",
+    "@types/node": "17.0.21",
     "@types/nouislider": "^9.0.10",
     "@types/passport": "^1.0.7",
     "@types/puppeteer": "^5.4.5",


### PR DESCRIPTION
For CI build (`npm ci`), versions define in `package-lock.json` must match those in `package.json`. Currently @types/node doesn't. This PR fixes that.